### PR TITLE
Delete company address

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,4 +136,4 @@ others do the same**.
 ------
 
 
-DWYL LTD is incorporated and registered in England and Wales with company number 09525434 and registered office is at DWYL LTD, 104 Mary Datchelor Close, London, SE5 7DY, United Kingdom.
+DWYL LTD is incorporated and registered in England and Wales with company number 09525434


### PR DESCRIPTION
Ref: https://github.com/dwyl/hq/issues/528

Address isn't needed here and only adds another task every time the office moves - our company number is sufficient because the registered address is displayed on Companies House publicly.