### PR TITLE
Adds link in README to mission.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,9 @@
 
 The hq repo is the home of all of dwyl's operations and administration.
 
-# Mission Statement
-dwyl exists with one mission in mind:
-> Empower people to sustainably unlock their potential and pursue their passion.
-
-If you'd like to know more or join the dwyl community,
-please read on or take a look at https://github.com/dwyl/start-here
+If you'd like to know more about dwyl's purpose and aims or
+to join the dwyl community,
+please take a look at https://github.com/dwyl/start-here
 
 
 # One Metric That Matters


### PR DESCRIPTION
Updates the README  by removing the out of date mission statement and updating it with a link to the single source of truth for this, `mission.md` in the start here repo.

#542